### PR TITLE
Adds query builder cmdlets

### DIFF
--- a/src/EFPosh/EFPosh/PoshEntityQuery.cs
+++ b/src/EFPosh/EFPosh/PoshEntityQuery.cs
@@ -51,6 +51,10 @@ namespace EFPosh
             _fromSql = fromSql;
             _fromSqlParams = fromSqlParams;
         }
+        public List<string> GetProperties()
+        {
+            return typeof(T).GetProperties().Select(p => p.Name).ToList();
+        }
         public PoshEntityQueryBase<T> AsNoTracking()
         {
             _baseIQueryable = _baseIQueryable.AsNoTracking();
@@ -174,14 +178,32 @@ namespace EFPosh
         }
         public PoshEntityJoiner<T> Contains(object equalValue)
         {
-            _whereQuery += $"{_columnName}.Contains(@{_whereParams.Count}) ";
-            _whereParams.Add(equalValue);
+            var equalValueType = equalValue.GetType();
+            if (equalValueType.IsArray)
+            {
+                _whereQuery += $"@{_whereParams.Count}.Contains({_columnName}) ";
+                _whereParams.Add(equalValue);
+            }
+            else
+            {
+                _whereQuery += $"{_columnName}.Contains(@{_whereParams.Count}) ";
+                _whereParams.Add(equalValue);
+            }
             return GetReturnObject();
         }
         public PoshEntityJoiner<T> NotContains(object equalValue)
         {
-            _whereQuery += $"!{_columnName}.Contains(@{_whereParams.Count}) ";
-            _whereParams.Add(equalValue);
+            var equalValueType = equalValue.GetType();
+            if (equalValueType.IsArray)
+            {
+                _whereQuery += $"!@{_whereParams.Count}.Contains({_columnName}) ";
+                _whereParams.Add(equalValue);
+            }
+            else
+            {
+                _whereQuery += $"!{_columnName}.Contains(@{_whereParams.Count}) ";
+                _whereParams.Add(equalValue);
+            }
             return GetReturnObject();
         }
         public PoshEntityJoiner<T> StartsWith(object equalValue)

--- a/src/Module/EFPosh/Commands/Add-EFPoshQuery.ps1
+++ b/src/Module/EFPosh/Commands/Add-EFPoshQuery.ps1
@@ -82,7 +82,7 @@ Function Add-EFPoshQuery {
         }
     }
     if($BoolSetComparision){
-        $Script:EFPoshQuery = $Script:EFPoshQuery."$($PSCmdlet.ParameterSetName)"($ComparisionValue)
+        $Script:EFPoshQuery = $Script:EFPoshQuery."$($Property)"."$($PSCmdlet.ParameterSetName)"($ComparisionValue)
     }
     else{
         throw "This should never be hit - if you see this error, the cool thing I did didn't work - Create an issue on GitHub with this error"

--- a/src/Module/EFPosh/Commands/Add-EFPoshQuery.ps1
+++ b/src/Module/EFPosh/Commands/Add-EFPoshQuery.ps1
@@ -1,0 +1,96 @@
+Function Add-EFPoshQuery {
+    Param(
+        [Parameter(Mandatory=$true, ParameterSetName = 'Equals')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'NotEquals')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'Contains')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'NotContains')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'StartsWith')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'EndsWith')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'LessThan')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'GreaterThan')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'GreaterThanOrEqualTo')]
+        [Parameter(Mandatory=$true, ParameterSetName = 'LessThanOrEqualTo')]
+        [ArgumentCompleter({
+            Param($CommandName, $ParameterName, $WordToComplete, $CommandAst, $FakeBoundParameters)
+            $PoshQuery = ( Get-Module EFPosh ).Invoke( { $Script:EFPoshQuery } )
+            $PropertyList = $PoshQuery.GetProperties()
+            foreach($instance in $PropertyList){
+                if($instance -like "$($WordToComplete)*"){
+                    New-Object System.Management.Automation.CompletionResult (
+                        $instance,
+                        $instance,
+                        'ParameterValue',
+                        $instance
+                    )
+                }
+            }
+        })]
+        [string]$Property,
+        [Parameter(Mandatory=$true, ParameterSetName = 'Equals')]
+        [object]$Equals,
+        [Parameter(Mandatory=$true, ParameterSetName = 'NotEquals')]
+        [object]$NotEquals,
+        [Parameter(Mandatory=$true, ParameterSetName = 'Contains')]
+        [object]$Contains,
+        [Parameter(Mandatory=$true, ParameterSetName = 'NotContains')]
+        [object]$NotContains,
+        [Parameter(Mandatory=$true, ParameterSetName = 'StartsWith')]
+        [object]$StartsWith,
+        [Parameter(Mandatory=$true, ParameterSetName = 'EndsWith')]
+        [object]$EndsWith,
+        [Parameter(Mandatory=$true, ParameterSetName = 'GreaterThan')]
+        [object]$GreaterThan,
+        [Parameter(Mandatory=$true, ParameterSetName = 'LessThan')]
+        [object]$LessThan,
+        [Parameter(Mandatory=$true, ParameterSetName = 'GreaterThanOrEqualTo')]
+        [object]$GreaterThanOrEqualTo,
+        [Parameter(Mandatory=$true, ParameterSetName = 'LessThanOrEqualTo')]
+        [object]$LessThanOrEqualTo,
+        [Parameter(Mandatory=$false, ParameterSetName = 'Equals')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'NotEquals')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Contains')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'NotContains')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'StartsWith')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'EndsWith')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'LessThan')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'GreaterThan')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'GreaterThanOrEqualTo')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'LessThanOrEqualTo')]
+        [switch]$And,
+        [Parameter(Mandatory=$false, ParameterSetName = 'Equals')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'NotEquals')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Contains')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'NotContains')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'StartsWith')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'EndsWith')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'LessThan')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'GreaterThan')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'GreaterThanOrEqualTo')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'LessThanOrEqualTo')]
+        [switch]$Or
+    )
+    if($null -eq $Script:EFPoshQuery){
+        throw 'Please run New-EFPoshQuery first and select which Entity we are querying against'
+        return
+    }
+    $ComparisionValue = $null
+    $BoolSetComparision = $false
+    foreach($var in $PSBoundParameters.Keys){
+        if($var -ne 'Or' -and $var -ne 'And' -and $var -ne 'Property'){
+            $ComparisionValue = $PSBoundParameters[$var]
+            $BoolSetComparision = $true
+        }
+    }
+    if($BoolSetComparision){
+        $Script:EFPoshQuery = $Script:EFPoshQuery."$($PSCmdlet.ParameterSetName)"($ComparisionValue)
+    }
+    else{
+        throw "This should never be hit - if you see this error, the cool thing I did didn't work - Create an issue on GitHub with this error"
+    }
+    if($Or) {
+        $Script:EFPoshQuery = $Script:EFPoshQuery.Or
+    }
+    if($And){
+        $Script:EFPoshQuery = $Script:EFPoshQuery.And
+    }
+}

--- a/src/Module/EFPosh/Commands/New-EFPoshQuery.ps1
+++ b/src/Module/EFPosh/Commands/New-EFPoshQuery.ps1
@@ -18,7 +18,19 @@ Function New-EFPoshQuery {
                 }
             }
         })]
-        [string]$Entity
+        [string]$Entity,
+        [Parameter(Mandatory = $false)]
+        [string]$FromQuery,
+        [object[]]$FromQueryParams
     )
-    return $DBContext."$Entity"
+    $Script:EFPoshQuery = $null
+    $Script:EFPoshQuery = $DBContext."$Entity"
+    if($FromQuery){
+        if($FromQueryParams){
+            $Script:EFPoshQuery = $Script:EFPoshQuery.FromQuery($FromQuery, $FromQueryParams)
+        }
+        else{
+            $Script:EFPoshQuery = $Script:EFPoshQuery.FromQuery($FromQuery)
+        }
+    }
 }

--- a/src/Module/EFPosh/Commands/Start-EFPoshQuery.ps1
+++ b/src/Module/EFPosh/Commands/Start-EFPoshQuery.ps1
@@ -1,0 +1,68 @@
+Function Start-EFPoshQuery{
+    [CmdletBinding(DefaultParameterSetName='ToList')]
+    Param(
+        [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
+        [switch]$AsNoTracking,
+        [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
+        [int]$Take,
+        [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
+        [int]$Skip,
+        [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
+        [string]$OrderBy,
+        [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
+        [string]$OrderByDescending,
+        [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
+        [switch]$Distinct,
+        [Parameter(Mandatory=$true, ParameterSetName = 'ToList')]
+        [switch]$ToList,
+        [Parameter(Mandatory=$true, ParameterSetName = 'FirstOrDefault')]
+        [switch]$FirstOrDefault,
+        [Parameter(Mandatory=$true, ParameterSetName = 'Any')]
+        [switch]$Any
+    )
+    if($null -eq $Script:EFPoshQuery){
+        throw 'Please run New-EFPoshQuery first and select which Entity we are querying against'
+        return
+    }
+    if($AsNoTracking){
+        $Script:EFPoshQuery = $Script:EFPoshQuery.AsNoTracking()
+    }
+    if($Take){
+        $Script:EFPoshQuery = $Script:EFPoshQuery.Take($Take)
+    }
+    if($Skip){
+        $Script:EFPoshQuery = $Script:EFPoshQuery.Skip($Skip)
+    }
+    if($OrderBy){
+        $Script:EFPoshQuery = $Script:EFPoshQuery.OrderBy($OrderBy)
+    }
+    if($OrderByDescending){
+        $Script:EFPoshQuery = $Script:EFPoshQuery.OrderBy("$OrderByDescending descending")
+    }
+    if($Distinct){
+        $Script:EFPoshQuery = $Script:EFPoshQuery.Distinct()
+    }
+    $tempQuery = $Script:EFPoshQuery
+    $Script:EFPoshQuery = $null
+    if($ToList){
+        return $tempQuery.ToList()
+    }
+    if($FirstOrDefault){
+        return $tempQuery.FirstOrDefault()
+    }
+    if($Any){
+        return $tempQuery.Any()
+    }
+}

--- a/src/Module/EFPosh/EFPosh.psd1
+++ b/src/Module/EFPosh/EFPosh.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\EFPosh.psm1'
 
 # Version number of this module.
-ModuleVersion = '0.2.0'
+ModuleVersion = '0.2.1'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()
@@ -74,7 +74,9 @@ FunctionsToExport = @(
     'New-EFPoshEntityDefinition', 
     'Start-EFPoshModel', 
     'Add-EFPoshModelEntity',
-    'New-EFPoshQuery'
+    'New-EFPoshQuery',
+    'Add-EFPoshQuery',
+    'Start-EFPoshQuery'
 )
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.

--- a/src/TestModule.ps1
+++ b/src/TestModule.ps1
@@ -53,6 +53,8 @@ $Results1 = $Context.TestTableTwo.Name.Equals("MyTest2").And.MyOtherUniqueId.Equ
 $results2 = $Context.TestTableTwo.Name.NotEquals("MyTest2").ToList()
 $Context.TestTableTwo.Name.Contains("2").ToList()
 
+
+
 return
 
 $QueryObject = New-EFPoshQuery -Type 'TestTableTwo'


### PR DESCRIPTION
Queries can be built today with the following syntax:

``` PowerShell
$Context.TableName.ColumnName.Equals("Value").ToList()
```

But since I use dynamic objects to do the above, tab completion doesn't work. This creates a series of cmdlets that let users build the query with cmdlets that have auto complete, so the above turns into:

``` PowerShell
New-EFPoshQuery -DBContext $Context -Entity TableName
Add-EFPoshQuery -Property ColumnName -Equals 'Value'
Start-EFPoshQuery -ToList
```

The above has auto complete for Entity on "New-EFPoshQuery" and Property on Add-EFPoshQuery so you can build the query without having to constantly re-check your model.