### PR TITLE
Fixes scoped variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ You can query for existing objects:
 Search-EFPosh -Entity $Context.TestTableTwo -Expression { $_.Name -eq 'MyTest' }
 ```
 
+Querying with variables is easy also, but not straight-forward:
+
+``` PowerShell
+$SearchFor = 'MyTest'
+Search-EFPosh -Entity $Context.TestTableTwo -Expression { $_.Name -eq $0 } -Arguments @($SearchFor)
+```
+
+In the above example, use number variables representing the index in the Arguments array. So $0 corresponds to index 0 in Arguments.
+
 You can easily edit objects in the database:
 
 ``` PowerShell

--- a/src/EFPosh/BinaryExpressionConverter/ConvertToBinaryExpression.cs
+++ b/src/EFPosh/BinaryExpressionConverter/ConvertToBinaryExpression.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Management.Automation;
 using System.Management.Automation.Language;
@@ -15,6 +16,10 @@ namespace BinaryExpressionConverter
             Position = 1,
             Mandatory = true)]
         public ScriptBlock Expression { get; set; }
+        [Parameter(
+            Position = 2,
+            Mandatory = false)]
+        public object[] Arguments { get; set; }
 
         private IPoshBinaryConverter _binaryConverter;
         private BinaryExpressionAst _binaryExpressionAst;
@@ -34,7 +39,7 @@ namespace BinaryExpressionConverter
         protected override void ProcessRecord() { }
         protected override void EndProcessing() 
         {
-            WriteObject(_binaryConverter.ConvertBinaryExpression(_binaryExpressionAst));
+            WriteObject(_binaryConverter.ConvertBinaryExpression(_binaryExpressionAst, Arguments));
         }
     }
 }

--- a/src/EFPosh/BinaryExpressionConverter/IPoshBinaryConverter.cs
+++ b/src/EFPosh/BinaryExpressionConverter/IPoshBinaryConverter.cs
@@ -9,6 +9,6 @@ namespace BinaryExpressionConverter
 {
     public interface IPoshBinaryConverter
     {
-        object ConvertBinaryExpression(BinaryExpressionAst binaryExpression);
+        object ConvertBinaryExpression(BinaryExpressionAst binaryExpression, object[] Arguments);
     }
 }

--- a/src/Module/EFPosh/Commands/Search-EFPosh.ps1
+++ b/src/Module/EFPosh/Commands/Search-EFPosh.ps1
@@ -11,6 +11,9 @@ Function Search-EFPosh{
     
     .PARAMETER Expression
     Expression to run against the entity
+
+    .PARAMETER Arguments
+    Arguments for the expression when $0 is used
     
     .PARAMETER AsNoTracking
     Should tracking be set up? If you don't want to edit the results, this could significantly reduce the query time
@@ -49,7 +52,7 @@ Function Search-EFPosh{
     Search-EFPosh -Entity $Context.TableOne -Expression { $_.Name -eq 'Test' }
 
     .EXAMPLE
-    Search-EFPosh -Entity $Context.TableOne -Expression { $_.Name -contains $Example }
+    Search-EFPosh -Entity $Context.TableOne -Expression { $_.Name -contains $0 } -Arguments @($Example)
     
     .NOTES
     .Author: Ryan Ephgrave
@@ -64,6 +67,10 @@ Function Search-EFPosh{
         [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
         [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
         [ScriptBlock]$Expression,
+        [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
+        [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
+        [object[]]$Arguments,
         [Parameter(Mandatory=$false, ParameterSetName = 'ToList')]
         [Parameter(Mandatory=$false, ParameterSetName = 'FirstOrDefault')]
         [Parameter(Mandatory=$false, ParameterSetName = 'Any')]
@@ -104,7 +111,7 @@ Function Search-EFPosh{
         [switch]$Any
     )
     if($Expression){
-        $ConvertedExpression = ConvertTo-BinaryExpression -FuncType $Entity.GetBaseType() -Expression $Expression
+        $ConvertedExpression = ConvertTo-BinaryExpression -FuncType $Entity.GetBaseType() -Expression $Expression -Arguments @($Arguments)
         $Entity.ApplyExpression($ConvertedExpression)
     }
     if($PSCmdlet.ParameterSetName -eq 'ToList'){

--- a/src/Module/EFPosh/EFPosh.psd1
+++ b/src/Module/EFPosh/EFPosh.psd1
@@ -12,7 +12,7 @@
 RootModule = '.\EFPosh.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.2.2'
+ModuleVersion = '1.2.3'
 
 # Supported PSEditions
 # CompatiblePSEditions = @()

--- a/src/Module/EFPosh/EFPosh.psm1
+++ b/src/Module/EFPosh/EFPosh.psm1
@@ -1,6 +1,5 @@
 
 Import-Module "$PSSCriptRoot\Dependencies\BinaryExpressionConverter.dll" -Force
-
 $CommandFiles = Get-ChildItem -Path "$PSScriptRoot\Commands" -Filter '*.ps1'
 foreach($file in $CommandFiles){
     Write-Verbose "Importing $($file.FullName)"


### PR DESCRIPTION
Closes #4 by introducing Arguments to Search-EFPosh.  Now variables can be defined in this manner:

```
{ $_.Name -eq $0 } -Arguments @($ValueOf0)
```
